### PR TITLE
fix power usage of wireless terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![build master](https://github.com/Mari023/AE2WirelessTerminalLibrary/actions/workflows/build_master.yml/badge.svg)](https://github.com/Mari023/AE2WirelessTerminalLibrary/actions/workflows/build_master.yml)
-[![Curseforge downloads](http://cf.way2muchnoise.eu/full_459929_downloads.svg)](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2-wireless-terminals-forge)
-[![Curseforge Versions](http://cf.way2muchnoise.eu/versions/459929.svg)](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2-wireless-terminals/files)
+[![build master](https://github.com/Tfarcenim/AE2WirelessTerminalLibrary/actions/workflows/build_master.yml/badge.svg)](https://github.com/Tfarcenim/AE2WirelessTerminalLibrary/actions/workflows/build_master.yml)
+[![Curseforge downloads](http://cf.way2muchnoise.eu/full_483310_downloads.svg)](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2-wireless-terminals-forge)
+[![Curseforge Versions](http://cf.way2muchnoise.eu/versions/483310.svg)](https://www.curseforge.com/minecraft/mc-mods/applied-energistics-2-wireless-terminals/files)
 
 Applied Energistics 2 Wireless Terminals
 ========================================

--- a/src/main/java/tfar/ae2wt/WTConfig.java
+++ b/src/main/java/tfar/ae2wt/WTConfig.java
@@ -6,11 +6,11 @@ public class WTConfig {
 
     public static double getPowerMultiplier(double range, boolean isOutOfRange) {
         if(!isOutOfRange) return AEConfig.instance().wireless_getDrainRate(range);
-        return AEConfig.instance().wireless_getDrainRate(16 * getOutOfRangePowerMultiplier());
+        return AEConfig.instance().wireless_getDrainRate(528 * getOutOfRangePowerMultiplier());//the drain rate while in range is dependent on the distance, and calculated by ae2. since 528 blocks is the max distance a terminal can normally work, out of range has to calculate the power with max range, or otherwise it uses less energy when out of range than at the edge of range
     }
 
     public static double getChargeRate() {
-        return 32000;
+        return 32000;//8000 is ae2's default charge rate, so I chose to use it too
     }
 
     public static double WUTChargeRateMultiplier() {
@@ -18,6 +18,6 @@ public class WTConfig {
     }
 
     private static int getOutOfRangePowerMultiplier() {
-        return 2;
+        return 2;//has to be > 1 for terminals to use more energy outside of range than in range
     }
 }

--- a/src/main/java/tfar/ae2wt/terminal/WTGuiObject.java
+++ b/src/main/java/tfar/ae2wt/terminal/WTGuiObject.java
@@ -81,7 +81,7 @@ public class WTGuiObject implements IGuiItemObject, IEnergySource, IActionHost, 
                         return testWap(myWap) || hasBoosterCard;
                     }
                     return hasBoosterCard;
-                }
+                } else isOutOfRange = true;
 
                 final IMachineSet tw = targetGrid.getMachines(WirelessTileEntity.class);
 
@@ -134,7 +134,6 @@ public class WTGuiObject implements IGuiItemObject, IEnergySource, IActionHost, 
             }
         }
         isOutOfRange = true;
-        if(((IInfinityBoosterCardHolder) effectiveItem.getItem()).hasBoosterCard(effectiveItem)) return true;
         return false;
     }
 


### PR DESCRIPTION
(contains #13)

the drain rate while in range is dependent on the distance, and calculated by ae2.
528 blocks is the max distance a terminal can normally work
out of range has to use at least max range to calculate the drain rate, or otherwise it uses less energy when out of range than at the edge of range

If you want the drain rate out of range to be lower, there is the out of range multiplier for this.
Keep in mind that values of less than 1 will have the problem of out of range being cheaper than edge of max range