### PR TITLE
Fix returning to the wrong screen after opening crafting status

### DIFF
--- a/src/main/java/tfar/ae2wt/mixin/ContainerTypeBuilderMixin.java
+++ b/src/main/java/tfar/ae2wt/mixin/ContainerTypeBuilderMixin.java
@@ -1,0 +1,47 @@
+package tfar.ae2wt.mixin;
+
+import appeng.container.ContainerLocator;
+import appeng.container.implementations.ContainerTypeBuilder;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import tfar.ae2wt.terminal.AbstractWirelessTerminalItem;
+import tfar.ae2wt.wirelesscraftingterminal.WCTGuiObject;
+import tfar.ae2wt.wirelesscraftingterminal.WCTItem;
+import tfar.ae2wt.wirelessinterfaceterminal.WITGuiObject;
+import tfar.ae2wt.wirelessinterfaceterminal.WITItem;
+import tfar.ae2wt.wpt.WPTGuiObject;
+import tfar.ae2wt.wpt.WPTItem;
+
+@Mixin(value = ContainerTypeBuilder.class, remap = false)
+public class ContainerTypeBuilderMixin<I> {
+    @Shadow
+    @Final
+    private Class<I> hostInterface;
+
+    @Inject(method = "getHostFromPlayerInventory", at = @At(value = "HEAD"), cancellable = true)
+    private void getWirelessHostFromPlayerInventory(PlayerEntity player, ContainerLocator locator, CallbackInfoReturnable<I> cir) {
+        ItemStack it = player.inventory.getStackInSlot(locator.getItemIndex());
+
+        if (it.isEmpty()) {
+            return;
+        }
+
+        // FIXME: this shouldn't be hardcoded
+        if (it.getItem() instanceof AbstractWirelessTerminalItem) {
+            AbstractWirelessTerminalItem awti = (AbstractWirelessTerminalItem)it.getItem();
+            if (awti instanceof WCTItem) {
+                cir.setReturnValue(hostInterface.cast(new WCTGuiObject(awti, it, player, locator.getItemIndex())));
+            } else if (awti instanceof WPTItem) {
+                cir.setReturnValue(hostInterface.cast(new WPTGuiObject(awti, it, player, locator.getItemIndex())));
+            } else if (awti instanceof WITItem) {
+                cir.setReturnValue(hostInterface.cast(new WITGuiObject(awti, it, player, locator.getItemIndex())));
+            }
+        }
+    }
+}

--- a/src/main/java/tfar/ae2wt/wirelesscraftingterminal/WirelessCraftingTerminalContainer.java
+++ b/src/main/java/tfar/ae2wt/wirelesscraftingterminal/WirelessCraftingTerminalContainer.java
@@ -8,6 +8,7 @@ import com.mojang.datafixers.util.Pair;
 
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.entity.player.ServerPlayerEntity;
 import net.minecraft.inventory.CraftingInventory;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.container.PlayerContainer;
@@ -22,6 +23,7 @@ import net.minecraft.world.World;
 
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.PlayerInvWrapper;
 
@@ -82,7 +84,7 @@ public class WirelessCraftingTerminalContainer extends ItemTerminalContainer imp
         WCTGuiObject accessInterface = new WCTGuiObject((AbstractWirelessTerminalItem) it.getItem(), it, player, locator.getItemIndex());
 
         if (locator.hasItemIndex()) {
-            player.openContainer(new TermFactory(accessInterface,locator));
+            NetworkHooks.openGui((ServerPlayerEntity) player, new TermFactory(accessInterface, locator));
         }
     }
 

--- a/src/main/java/tfar/ae2wt/wirelessfluidterminal/WirelessFluidTerminalContainer.java
+++ b/src/main/java/tfar/ae2wt/wirelessfluidterminal/WirelessFluidTerminalContainer.java
@@ -24,6 +24,7 @@ import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fluids.FluidUtil;
 import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.fluids.capability.IFluidHandlerItem;
+import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.items.IItemHandler;
 import tfar.ae2wt.init.Menus;
 import tfar.ae2wt.terminal.AbstractWirelessTerminalItem;
@@ -45,7 +46,7 @@ public class WirelessFluidTerminalContainer extends MEMonitorableContainer<IAEFl
         WFluidTGuiObject accessInterface = new WFluidTGuiObject((AbstractWirelessTerminalItem) it.getItem(), it, player, locator.getItemIndex());
 
         if (locator.hasItemIndex()) {
-            player.openContainer(new TermFactory(accessInterface,locator));
+            NetworkHooks.openGui((ServerPlayerEntity) player, new TermFactory(accessInterface,locator));
         }
     }
 

--- a/src/main/java/tfar/ae2wt/wirelessinterfaceterminal/WirelessInterfaceTerminalContainer.java
+++ b/src/main/java/tfar/ae2wt/wirelessinterfaceterminal/WirelessInterfaceTerminalContainer.java
@@ -33,6 +33,7 @@ import net.minecraft.nbt.CompoundNBT;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Util;
 import net.minecraft.util.text.ITextComponent;
+import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.fml.network.PacketDistributor;
 import net.minecraftforge.items.IItemHandler;
 import tfar.ae2wt.WTConfig;
@@ -63,7 +64,7 @@ public class WirelessInterfaceTerminalContainer extends AEBaseContainer {
         WTGuiObject accessInterface = new WITGuiObject((AbstractWirelessTerminalItem) it.getItem(), it, player, locator.getItemIndex());
 
         if (locator.hasItemIndex()) {
-            player.openContainer(new TermFactory(accessInterface,locator));
+            NetworkHooks.openGui((ServerPlayerEntity) player, new TermFactory(accessInterface,locator));
         }
 
     }

--- a/src/main/java/tfar/ae2wt/wpt/WirelessPatternTerminalContainer.java
+++ b/src/main/java/tfar/ae2wt/wpt/WirelessPatternTerminalContainer.java
@@ -42,6 +42,7 @@ import net.minecraft.item.crafting.IRecipeType;
 import net.minecraft.util.Hand;
 import net.minecraft.util.Util;
 import net.minecraft.world.World;
+import net.minecraftforge.fml.network.NetworkHooks;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
 import tfar.ae2wt.WTConfig;
@@ -79,7 +80,7 @@ public class WirelessPatternTerminalContainer extends ItemTerminalContainer impl
         WPTGuiObject accessInterface = new WPTGuiObject((AbstractWirelessTerminalItem) it.getItem(), it, player, locator.getItemIndex());
 
         if (locator.hasItemIndex()) {
-            player.openContainer(new TermFactory(accessInterface,locator));
+            NetworkHooks.openGui((ServerPlayerEntity) player, new TermFactory(accessInterface,locator));
         }
     }
 

--- a/src/main/resources/ae2wtlib.mixins.json
+++ b/src/main/resources/ae2wtlib.mixins.json
@@ -7,6 +7,7 @@
   "mixins": [
     "AEBaseContainerAccess",
     "ContainerAccess",
+    "ContainerTypeBuilderMixin",
     "CraftConfirmContainerMixin",
     "InvActionPacketMixin",
     "PlayerInventoryMixin",


### PR DESCRIPTION
This happens because `CraftingStatusContainer` ultimately calls `ContainerTypeBuilder#open`, which will create a WirelessTerminalGuiObject (for the AE2 wireless terminal) rather than a subclass of WTGuiObject (from this mod) ([relevant AE2 code](https://github.com/AppliedEnergistics/Applied-Energistics-2/blob/b45c590639a0ed0e6dd2cd60a3263b4546cd53c5/src/main/java/appeng/container/implementations/ContainerTypeBuilder.java#L246-L251)). The mixin fixes this.

When returning to the previous screen, `SwitchGuisPacket` uses `ContainerOpener`, so the code in Menus adds handlers for the extra wireless terminals. My Java is pretty rusty, so there may be a simpler/cleaner way to do that, but this seems to work.