### PR TITLE
Fix #28

### DIFF
--- a/src/main/java/tfar/ae2wt/terminal/WTGuiObject.java
+++ b/src/main/java/tfar/ae2wt/terminal/WTGuiObject.java
@@ -148,6 +148,12 @@ public abstract class WTGuiObject implements IGuiItemObject, IEnergySource, IAct
         if(myWap != null) {
             return myWap.getActionableNode();
         }
+        Item item = effectiveItem.getItem();
+        if (item instanceof IInfinityBoosterCardHolder && ((IInfinityBoosterCardHolder) item).hasBoosterCard(effectiveItem)) {
+            if (targetGrid != null) {
+                return targetGrid.getPivot();
+            }
+        }
         return null;
     }
 


### PR DESCRIPTION
Based on p455w0rd's original implementation. If all the WAPs are out of range, `myWap` never gets set, so `getActionableNode()` incorrectly returns null.

Needs #34 or another fix for that bug to be merged.